### PR TITLE
Fe 363 updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cielo-finance/component-library",
-  "version": "0.0.115-development",
+  "version": "0.0.116-development",
   "description": "Lightweight react component library build with atomic design.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/buttons/button.tsx
+++ b/src/atoms/buttons/button.tsx
@@ -15,6 +15,7 @@ const Button = Styled.button<GenericStylingProps>`
   font-weight: 700;
   color: ${(props) => props.theme.colors.system.WHITE};
   border-radius: ${(props) => props.borderRadius || '12px'};
+  justify-content: center;
   cursor: ${(props) => (props.disabled ? 'default' : 'pointer')};
   .button__group {
     display: flex;

--- a/src/atoms/chips/filterChip.stories.tsx
+++ b/src/atoms/chips/filterChip.stories.tsx
@@ -2,9 +2,10 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React, { useState } from 'react';
 import { FilterChip } from './filterChip';
 import {
-  AllIcon, CoinStandard, ImageIcon, StarIcon,
+  AllIcon, CoinStandard, ImageIcon, Microscope, Sonar, StarIcon, Suitcase, WebinarStandard,
 } from '../icons';
 import { Styled } from '../../theme';
+import { Text } from '../texts/text';
 
 interface Filter {
   id: number;
@@ -26,6 +27,34 @@ const filtersArray = [
     id: 3, value: 'nFTs', label: 'NFTs', icon: <ImageIcon />,
   },
 ];
+
+const newsdeskStories: any[] = [
+  {
+    label: 'All',
+    icon: <AllIcon />,
+    id: 'all',
+  },
+  {
+    label: 'Social Sonar',
+    icon: <Sonar />,
+    id: 'sonar',
+  },
+  {
+    label: 'VC Deals',
+    icon: <Suitcase />,
+    id: 'vcdeals',
+  },
+  {
+    label: 'Latest Research',
+    icon: <Microscope />,
+    id: 'research',
+  },
+  {
+    label: 'Webinars',
+    icon: <WebinarStandard />,
+    id: 'webinars',
+  },
+];
 const Wrapper = Styled.div`
   display: flex;
   align-items: center;
@@ -39,19 +68,22 @@ export default {
 
 } as ComponentMeta<typeof FilterChip>;
 
+const DataPresets = [filtersArray, newsdeskStories];
+
 const Template: ComponentStory<typeof FilterChip> = (props) => {
   const [selectFilter, setSelectFilter] = useState<number>();
+  const { id } = props;
   return (
     <Wrapper>
-      {filtersArray
+      {DataPresets[id]
         .map((chip: Filter) => (
           <FilterChip
             {...chip}
             {...props}
-            onClick={(v: any) => setSelectFilter(v)}
+            onClick={(_id) => setSelectFilter(_id)}
             isOn={selectFilter === chip.id}
           >
-            {chip.label}
+            <Text size="XS-Bold">{chip.label}</Text>
           </FilterChip>
         ))}
     </Wrapper>
@@ -59,7 +91,11 @@ const Template: ComponentStory<typeof FilterChip> = (props) => {
 };
 export const Primary = Template.bind({});
 export const PrimaryCustomWidth = Template.bind({});
+export const PrimaryNewsdesk = Template.bind({});
 
+Primary.args = { id: 0 };
 PrimaryCustomWidth.args = {
   width: '25%',
+  id: 0,
 };
+PrimaryNewsdesk.args = { id: 1 };

--- a/src/atoms/chips/filterChip.tsx
+++ b/src/atoms/chips/filterChip.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { MouseEvent } from 'react';
 import { CSSProperties } from 'styled-components';
 import { Styled } from '../../theme';
-import { Text } from '../texts/text';
 import { IconWrapper } from '../icons/iconWrapper';
 
 export type FilterChipProps = {
@@ -12,7 +11,7 @@ export type FilterChipProps = {
   | string[];
   icon: JSX.Element;
   isOn: boolean;
-  onClick: (e:unknown) => void;
+  onClick: (id: number, e: MouseEvent<HTMLElement>) => void;
   id: number;
 } & Pick<CSSProperties, 'width'>;
 const Wrapper = Styled.div<{ isOn: boolean } & Pick<CSSProperties, 'width'>>`
@@ -56,10 +55,10 @@ const Content = Styled.div`
 export const FilterChip = ({
   children, icon, isOn, onClick, id, width,
 }:FilterChipProps) => (
-  <Wrapper isOn={isOn} onClick={() => onClick(id)} width={width}>
+  <Wrapper isOn={isOn} onClick={(e: MouseEvent<HTMLElement>) => onClick(id, e)} width={width}>
     <Content>
-      <IconWrapper icon={icon} />
-      <Text size="S-Regular">{children}</Text>
+      <IconWrapper cursor="pointer" icon={icon} />
+      {children}
     </Content>
   </Wrapper>
 );

--- a/src/atoms/tags/tag.stories.tsx
+++ b/src/atoms/tags/tag.stories.tsx
@@ -21,12 +21,15 @@ const Template: ComponentStory<typeof Tag> = (args) => (
   <Wrapper>
     {mockData.map((item, index) => {
       const [isActive, setIsActive] = useState<boolean>(false);
+
       return (
         <Tag
           {...args}
           key={item}
           isOn={isActive}
-          onClick={() => setIsActive(!isActive)}
+          onClick={() => {
+            setIsActive(!isActive);
+          }}
           tabIndex={index}
         >
           {item}
@@ -37,10 +40,15 @@ const Template: ComponentStory<typeof Tag> = (args) => (
 );
 export const ContentTags = Template.bind({});
 export const ContentTagsCustomWidth = Template.bind({});
+export const CustomFontSize = Template.bind({});
 
 ContentTags.parameters = {
   backgrounds: { default: 'dark' },
 };
 ContentTagsCustomWidth.args = {
   width: '400px',
+};
+
+CustomFontSize.args = {
+  fontSize: 'H4-Bold',
 };

--- a/src/atoms/tags/tag.styles.ts
+++ b/src/atoms/tags/tag.styles.ts
@@ -1,18 +1,35 @@
 import { CSSProperties } from 'styled-components';
 import { TagProps } from './types';
-import { Styled } from '../../theme';
+import { Styled, Theme } from '../../theme';
 
-export type CustomTagProps = Pick<TagProps, 'isOn'> & Pick<CSSProperties, 'width' | 'border' | 'background'>;
+export type CustomTagProps = Pick<TagProps, 'isOn' | 'tabIndex'> & Pick<CSSProperties, 'width'>;
+
+const BackgroundAndBorderColors = [
+  { background: Theme.colors.primary.UWL_BLUE, border: `1px solid ${Theme.colors.primary.UWL_BLUE}` },
+  { background: Theme.colors.secondary.PURPLE, border: `1px solid ${Theme.colors.secondary.PURPLE}` },
+  { background: Theme.colors.secondary.TANGY, border: `1px solid ${Theme.colors.secondary.TANGY}` },
+  { background: Theme.colors.secondary.FUSCHIA, border: `1px solid ${Theme.colors.secondary.FUSCHIA}` },
+  { background: Theme.colors.primary.WATER_BLUE, border: `1px solid ${Theme.colors.primary.WATER_BLUE}` },
+  { background: Theme.colors.primary.DARK_BLUE, border: `1px solid ${Theme.colors.primary.DARK_BLUE}` },
+];
 
 export const CustomTag = Styled.div<CustomTagProps>`
   border-radius: 12px;
   padding: 4px 12px;
   cursor: pointer;
   width: ${({ width }) => width ?? 'fit-content'};
-  background: ${(props) => props.background};
-  border: ${(props) => props.border};
+  background: ${({ isOn, tabIndex }) => (isOn ? BackgroundAndBorderColors[tabIndex].background : 'none')};
   transition: all .3s;
   text-align: center;
+  border: ${({ tabIndex }) => BackgroundAndBorderColors[tabIndex].border};
+  
+  &:hover {
+    background: ${({ isOn, tabIndex }) => (isOn ? 'none' : BackgroundAndBorderColors[tabIndex].background)};
+    
+    & > *  {
+      color: ${({ theme, isOn }) => (isOn ? theme.textShades.SHADE_MINUS_3 : theme.colors.system.WHITE)};
+    }
+  }
 `;
 
 export const Wrapper = Styled.div`

--- a/src/atoms/tags/tag.tsx
+++ b/src/atoms/tags/tag.tsx
@@ -7,19 +7,10 @@ import {
 } from './tag.styles';
 
 export const Tag = ({
-  children, isOn, onClick, tabIndex, width,
+  children, isOn, onClick, tabIndex, width, fontSize,
 }: TagProps) => {
   const theme: any = useTheme();
   const textColour = isOn ? theme.colors.system.WHITE : theme.textShades.SHADE_MINUS_3;
-
-  const backgroundAndBorderColors = [
-    { background: isOn ? theme.colors.primary.UWL_BLUE : 'none', border: `1px solid ${theme.colors.primary.UWL_BLUE}` },
-    { background: isOn ? theme.colors.secondary.PURPLE : 'none', border: `1px solid ${theme.colors.secondary.PURPLE}` },
-    { background: isOn ? theme.colors.secondary.TANGY : 'none', border: `1px solid ${theme.colors.secondary.TANGY}` },
-    { background: isOn ? theme.colors.secondary.FUSCHIA : 'none', border: `1px solid ${theme.colors.secondary.FUSCHIA}` },
-    { background: isOn ? theme.colors.primary.WATER_BLUE : 'none', border: `1px solid ${theme.colors.primary.WATER_BLUE}` },
-    { background: isOn ? theme.colors.primary.DARK_BLUE : 'none', border: `1px solid ${theme.colors.primary.DARK_BLUE}` },
-  ];
 
   return (
     <CustomTag
@@ -28,10 +19,8 @@ export const Tag = ({
       key={tabIndex}
       isOn={isOn}
       tabIndex={tabIndex}
-      border={backgroundAndBorderColors[tabIndex % 6].border}
-      background={backgroundAndBorderColors[tabIndex % 6].background}
     >
-      <Text size="S-Bold" color={textColour}>{children}</Text>
+      <Text size={fontSize ?? 'S-Bold'} color={textColour}>{children}</Text>
     </CustomTag>
   );
 };

--- a/src/atoms/tags/types.ts
+++ b/src/atoms/tags/types.ts
@@ -1,9 +1,11 @@
-import { ReactChild } from 'react';
+import { MouseEvent, ReactChild } from 'react';
 import { CSSProperties } from 'styled-components';
+import { TextProps } from '../texts/types';
 
 export type TagProps = {
   children: ReactChild
   isOn: boolean;
   tabIndex: number;
-  onClick: () => void;
+  onClick: (e: MouseEvent<HTMLElement>) => void;
+  fontSize?: TextProps['size'];
 } & Pick<CSSProperties, 'width'>;

--- a/src/layouts/breakpoints.ts
+++ b/src/layouts/breakpoints.ts
@@ -2,32 +2,46 @@ import {
   css, DefaultTheme, FlattenInterpolation, ThemedStyledProps,
 } from 'styled-components';
 
+/* Breakpoints top ranges Phone 0 - 656, tablet 656-1024 etc. */
+export const WidthBreakpoints = Object.freeze({
+  Phone: { bottom: 0, top: 656 },
+  Tablet: { bottom: 657, top: 1024 },
+  SmallDesktop: { bottom: 1025, top: 1280 },
+  Desktop: { bottom: 1281, top: 1440 },
+  BigDesktop: { bottom: 1441, top: 99999 },
+});
+
+export const HeightBreakpoints = Object.freeze({
+  FixedHeight: { bottom: 0, top: 840 },
+});
+
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
 export const normalDesktop = (inner: FlattenInterpolation<ThemedStyledProps<any, AnyIfEmpty<DefaultTheme>>>) => css`
-    @media (max-width: 1440px) {
+    @media (max-width: ${WidthBreakpoints.Desktop.top}px) {
       ${inner};
     }
 `;
 export const smallDesktop = (inner: FlattenInterpolation<ThemedStyledProps<any, AnyIfEmpty<DefaultTheme>>>) => css`
-    @media (max-width: 1280px) {
+    @media (max-width: ${WidthBreakpoints.SmallDesktop.top}px) {
         ${inner};
     }
 `;
 
 export const tablet = (inner: FlattenInterpolation<ThemedStyledProps<any, AnyIfEmpty<DefaultTheme>>>) => css`
-    @media (max-width: 1024px) {
+    @media (max-width: ${WidthBreakpoints.Tablet.top}px) {
       ${inner};
     }
 `;
 
 export const phone = (inner:FlattenInterpolation<ThemedStyledProps<any, AnyIfEmpty<DefaultTheme>>>) => css`
-    @media (max-width: 650px) {
+    @media (max-width: ${WidthBreakpoints.Phone.top}px) {
       ${inner};
     }
   `;
+
 export const fixedHeight = (inner: FlattenInterpolation<ThemedStyledProps<{}, AnyIfEmpty<DefaultTheme>>> | any) => css`
-    @media (max-height: 840px) {
+    @media (max-height: ${HeightBreakpoints.FixedHeight.top}px) {
       ${inner};
     }
   `;

--- a/src/organisms/contentCard/contentCard.tsx
+++ b/src/organisms/contentCard/contentCard.tsx
@@ -62,7 +62,7 @@ export const ContentCard:FC<ContentCardProps> = ({
             />
           </MediaTypeIcon>
           {guest && <Text color={theme.textShades.SHADE_MINUS_2} size="S-Regular">with</Text>}
-          {guestLink && guest && <Text href={guestLink} color={theme.colors.system.GREEN} size="S-Regular">{guest}</Text>}
+          {guest && <Text href={guestLink} color={theme.colors.system.GREEN} size="S-Regular">{guest}</Text>}
         </AboutSectionLeftSide>
         <ButtonAtom buttonVariant="special_small_round" onClick={() => onClick()}>
           <IconWrapper

--- a/src/organisms/navbar/styles.tsx
+++ b/src/organisms/navbar/styles.tsx
@@ -7,7 +7,8 @@ const FlexBase = Styled.div`
 
 export const NavbarContainer = Styled(FlexBase)`
   height: 36px;
-  
+  position: sticky;
+  top: 0;
   justify-content: space-between;
   background-color: ${({ theme }) => theme.containerAndCardShades.SHADE_PLUS_3};
   box-shadow: ${({ theme }) => theme.dropShadow.REGULAR};


### PR DESCRIPTION
1. Centered content in buttons 
2. Added pointer to filter chip icons
3. FilterChip now requires text to be passed to it rather than just string
4. Added events to some onClicks to be able to prevent propagation in frontend repo
5. Added custom font size to tags
6. Fixed hovering effect of tags
7. Added Global object WidthBreakpoints with bottom/top ranges so that on frontend we can also do it to create custom media breakpoints if needed
8. Removed announcement card from comp library and moved it to frontend, as idk if that card will ever be reused
9. moved useBreakpoint hook here as it might be useful for building components.
10. Guest on content card will now show guest even if he didnt have his own social link

11. Waiting for Timur to tell me how to decide which content type icon show on content card as its showing wrong one atm. It will be in another pr