### PR TITLE
added fade pop up animation for icons on sticky bars

### DIFF
--- a/src/atoms/animations/fades.tsx
+++ b/src/atoms/animations/fades.tsx
@@ -27,3 +27,21 @@ export const keyframeFadeIn = keyframes`
 export const FadeIn = Styled.div`
   animation: ${keyframeFadeIn} 2s ease-in;
 `;
+
+export const keyframeFadePopUp = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  85% {
+    transform: scale(1.2);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
+
+export const FadePopUp = Styled.div`
+  animation: ${keyframeFadePopUp} 0.3s ease-in;
+`;

--- a/src/atoms/animations/fades.tsx
+++ b/src/atoms/animations/fades.tsx
@@ -1,5 +1,4 @@
-import { keyframes } from 'styled-components';
-import { Styled } from '../../theme';
+import { css, keyframes } from 'styled-components';
 
 export const keyframeFadeInTop = keyframes`
   from {
@@ -9,11 +8,19 @@ export const keyframeFadeInTop = keyframes`
   to { 
     opacity: 1;
   }
+  `;
+export const FadeInTop = css`animation: ${keyframeFadeInTop} 0.3s ease-in-out`;
+export const keyframeFadeOutTop = keyframes`
+  from {
+    opacity: 1;
+  }
+  to { 
+    opacity: 0;
+    transform: translateY(-100%);
+  }
 `;
 
-export const FadeInTop = Styled.div`
-  animation: ${keyframeFadeInTop} 2s linear;
-`;
+export const FadeOutTop = css`animation: ${keyframeFadeOutTop} 0.3s ease-in-out`;
 
 export const keyframeFadeIn = keyframes`
   from {
@@ -24,9 +31,7 @@ export const keyframeFadeIn = keyframes`
   }
 `;
 
-export const FadeIn = Styled.div`
-  animation: ${keyframeFadeIn} 2s ease-in;
-`;
+export const FadeIn = css`animation: ${keyframeFadeIn} 2s ease-in-out`;
 
 export const keyframeFadePopUp = keyframes`
   from {
@@ -42,6 +47,4 @@ export const keyframeFadePopUp = keyframes`
   }
 `;
 
-export const FadePopUp = Styled.div`
-  animation: ${keyframeFadePopUp} 0.3s ease-in;
-`;
+export const FadePopUp = css`animation: ${keyframeFadePopUp} 0.3s ease-in`;

--- a/src/atoms/common/overlay.tsx
+++ b/src/atoms/common/overlay.tsx
@@ -1,6 +1,8 @@
 import { Styled } from '../../theme';
+import { FadeIn } from '../animations/fades';
 
 export const Overlay = Styled.div`
+  ${FadeIn};
   width: 100%;
   height: 100%;
   left: 0;

--- a/src/atoms/modal/modal.tsx
+++ b/src/atoms/modal/modal.tsx
@@ -1,4 +1,6 @@
-import React, { FC, useEffect } from 'react';
+import React, {
+  FC, useEffect, useState,
+} from 'react';
 import { css } from 'styled-components';
 import { Styled } from '../../theme';
 import { phone, tablet } from '../../layouts/breakpoints';
@@ -8,6 +10,7 @@ import { IconWrapper } from '../icons/iconWrapper';
 import { Row } from '../common/flex';
 import { ModalBaseProps, ModalCardProps } from './types';
 import { Overlay } from '../common/overlay';
+import { FadeInTop, FadeOutTop } from '../animations/fades';
 
 export const ModalContainer = Styled.div`
   position: absolute;
@@ -21,7 +24,7 @@ export const ModalContainer = Styled.div`
   justify-content: center;
 `;
 
-export const ModalBody = Styled(Card)<ModalCardProps>`
+export const ModalBody = Styled(Card)<ModalCardProps & { replay: boolean }>`
   display: flex;
   flex-direction: column;
   position: relative;
@@ -30,8 +33,9 @@ export const ModalBody = Styled(Card)<ModalCardProps>`
   height: ${({ height }) => height ?? '62vh'};
   max-height: ${({ maxHeight }) => maxHeight ?? '600px'};
   box-shadow: ${({ theme }) => theme.dropShadow.REGULAR};
-
-  ${tablet(css`
+  
+  ${tablet(css<{ replay: boolean }>`
+    ${({ replay }) => (replay ? FadeOutTop : FadeInTop)};
     max-width: calc(100vw - 100px);
   `)}
 
@@ -51,20 +55,26 @@ const CloseButton = Styled(Row)`
 export const ModalBase: FC<ModalBaseProps> = ({
   children, closeFn, icon, height, maxHeight, maxWidth, noCloseIcon,
 }) => {
+  const [replay, setReplay] = useState(false);
+
   useEffect(() => {
     document.body.style.overflow = 'hidden';
+    console.debug(replay);
     return () => {
       document.body.style.overflow = 'unset';
     };
   }, []);
 
   return (
-    <Overlay
-      onClick={(e) => {
-        e.stopPropagation();
-        if (closeFn) closeFn(e);
-      }}
-    >
+    <>
+      <Overlay
+        onClick={(e) => {
+          e.stopPropagation();
+          if (!closeFn) return;
+          setReplay(true);
+          setTimeout(() => closeFn(e), 150);
+        }}
+      />
       <ModalContainer>
         <ModalBody
           height={height}
@@ -72,15 +82,25 @@ export const ModalBase: FC<ModalBaseProps> = ({
           maxWidth={maxWidth}
           onClick={(e) => e.stopPropagation()}
           noHover
+          replay={replay}
         >
           {!noCloseIcon && (
-          <CloseButton>
-            <IconWrapper width="15px" cursor="pointer" icon={icon ?? <CrossIcon />} onClick={closeFn} />
-          </CloseButton>
+            <CloseButton>
+              <IconWrapper
+                width="15px"
+                cursor="pointer"
+                icon={icon ?? <CrossIcon />}
+                onClick={(e) => {
+                  if (!closeFn) return;
+                  setReplay(true);
+                  setTimeout(() => closeFn(e), 150);
+                }}
+              />
+            </CloseButton>
           )}
           {children}
         </ModalBody>
       </ModalContainer>
-    </Overlay>
+    </>
   );
 };

--- a/src/atoms/modal/modalModel.tsx
+++ b/src/atoms/modal/modalModel.tsx
@@ -25,14 +25,14 @@ const AnnouncementCardContainerMobile = Styled.div`
 `;
 
 const Cover = Styled.div<{ coverUrl: string }>`
-    background: ${({ coverUrl }) => `url(${coverUrl})`};
-    height: 115px;
-    width: 233px;
-    margin-bottom: 20px;
-    border-radius: 8px;
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: center;
+  background: ${({ coverUrl }) => `url(${coverUrl})`};
+  height: 115px;
+  width: 233px;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
 `;
 
 const Content = Styled.div`

--- a/src/layouts/brochure/brochureLayout.styles.tsx
+++ b/src/layouts/brochure/brochureLayout.styles.tsx
@@ -6,6 +6,7 @@ export const BrochureLayout = Styled.div`
   flex-direction: column;
   display: flex;
   gap: 16px;
+  padding-top: 58px;
   
   div:nth-of-type(1) {
     height: 148px;

--- a/src/layouts/tools/toolingLayout.styles.tsx
+++ b/src/layouts/tools/toolingLayout.styles.tsx
@@ -7,6 +7,7 @@ export const ToolingLayoutOne = Styled.div<{ single?: boolean }>`
   min-width: 360px;
   margin: 0 auto;
   display: grid;
+  padding-top: 58px;
   gap: 25px;
   grid-template-columns: ${({ single }) => (single ? '' : 'minmax(500px, 1109px) minmax(331px, 450px)')};
   

--- a/src/molecules/stickyActionBar/stickyActionBar.tsx
+++ b/src/molecules/stickyActionBar/stickyActionBar.tsx
@@ -1,4 +1,7 @@
-import React, { FC, useRef } from 'react';
+import React, {
+  FC, useRef,
+} from 'react';
+import { FadePopUp } from '../../atoms/animations/fades';
 import { ButtonAtom } from '../../atoms/buttons/button';
 import { IconWrapper } from '../../atoms/icons/iconWrapper';
 import { Text } from '../../atoms/texts/text';
@@ -16,6 +19,7 @@ export const StickyActionBar: FC<StickyActionBarProps> = ({
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const isOnEdge = useScreenEdge({ rect: 'top', ref, rootMargin });
+
   return (
     <StickyActionBarWrapper
       {...cardProps}
@@ -32,9 +36,9 @@ export const StickyActionBar: FC<StickyActionBarProps> = ({
         </>
       )}
       {icon && withTransform && isOnEdge && (
-        <ButtonWrapper index={index} mt={mt}>
-          <ButtonAtom buttonVariant="secondary_action"><IconWrapper icon={icon} cursor="pointer" /></ButtonAtom>
-        </ButtonWrapper>
+      <ButtonWrapper isOnEdge={isOnEdge} index={index} mt={mt}>
+        <ButtonAtom buttonVariant="secondary_action"><IconWrapper icon={icon} cursor="pointer" /></ButtonAtom>
+      </ButtonWrapper>
       )}
     </StickyActionBarWrapper>
   );

--- a/src/molecules/stickyActionBar/styles.tsx
+++ b/src/molecules/stickyActionBar/styles.tsx
@@ -1,5 +1,6 @@
 import { css } from 'styled-components';
 import { Card } from '../../atoms/card/card';
+import { keyframeFadePopUp } from '../../atoms/animations/fades';
 import { Styled } from '../../theme';
 import { StickyActionBarProps, StickyActionBarWrapperProps } from './types';
 
@@ -19,7 +20,8 @@ export const StickyActionBarWrapper = Styled(Card)<StickyActionBarWrapperProps>`
   `}
 `;
 
-export const ButtonWrapper = Styled.div<Pick<StickyActionBarProps, 'index' | 'mt'>>`
+export const ButtonWrapper = Styled.div <Pick<StickyActionBarProps, 'index' | 'mt'> & Pick<StickyActionBarWrapperProps, 'isOnEdge'>>`
+  animation: ${({ isOnEdge }) => `${keyframeFadePopUp} cubic-bezier(0.785, 0.135, 0.15, 0.86) 0.3s ${isOnEdge ? 'forwards' : 'backwards'}`};
   position: sticky;
   margin-right: ${({ index }) => (index && (index > 1) ? (index * 48) : 0)}px;
   margin-top: ${({ mt }) => mt};

--- a/src/molecules/stickyActionBar/styles.tsx
+++ b/src/molecules/stickyActionBar/styles.tsx
@@ -21,7 +21,7 @@ export const StickyActionBarWrapper = Styled(Card)<StickyActionBarWrapperProps>`
 `;
 
 export const ButtonWrapper = Styled.div <Pick<StickyActionBarProps, 'index' | 'mt'> & Pick<StickyActionBarWrapperProps, 'isOnEdge'>>`
-  animation: ${({ isOnEdge }) => `${keyframeFadePopUp} cubic-bezier(0.785, 0.135, 0.15, 0.86) 0.3s ${isOnEdge ? 'forwards' : 'backwards'}`};
+  animation: ${({ isOnEdge }) => css`${keyframeFadePopUp} cubic-bezier(0.785, 0.135, 0.15, 0.86) 0.3s ${isOnEdge ? 'forwards' : 'backwards'}`};
   position: sticky;
   margin-right: ${({ index }) => (index && (index > 1) ? (index * 48) : 0)}px;
   margin-top: ${({ mt }) => mt};

--- a/src/organisms/navbar/components/UserMenu/styles.tsx
+++ b/src/organisms/navbar/components/UserMenu/styles.tsx
@@ -11,25 +11,23 @@ export const NavbarUserMenu = Styled.div<{ isMenuOpen: boolean }>`
   background-color: ${({ theme }) => theme.containerAndCardShades.SHADE_PLUS_3};
   box-shadow: ${({ theme }) => theme.dropShadow.REGULAR};
   width: 160px;
-  right: 24px;
-  top: 84px;
+  right: 16px;
+  top: 62px;
   padding: 14px;
   border-radius: 12px;
-  position: absolute;
+  position: fixed;
   max-width: 160px;
   transition: all 800ms ease-in-out;
   z-index: ${({ theme }) => theme.zIndex.USER_MENU};
 
   ${tablet(css<{ isMenuOpen: boolean }>`
+    padding: 8px;
     position: unset;
     background-color: transparent;
     border-radius: none;
     box-shadow: none;
-    top: unset;
-    bottom: 14px;
-    right: 14px;
     justify-content: flex-end;
-    width: 100%;
+    width: calc(100vw - 32px);
     max-width: unset;
   `)}
 `;

--- a/src/organisms/navbar/navbar.stories.tsx
+++ b/src/organisms/navbar/navbar.stories.tsx
@@ -18,6 +18,12 @@ export default {
 const Wrapper = Styled.div`
 `;
 
+const Dummy = Styled.div`
+  width: 100%;
+  height: 400px;
+  background-color: rgb(0, 0 ,0, 0.5);
+`;
+
 const Template: ComponentStory<typeof Navbar> = (
   args,
 ) => {
@@ -36,6 +42,18 @@ const Template: ComponentStory<typeof Navbar> = (
         account={account}
         onWalletConnectClick={() => handleSwitch()}
       />
+      <Dummy />
+      <Dummy />
+      <Dummy />
+      <Dummy />
+      <Dummy />
+      <Dummy />
+      <Dummy />
+      <Dummy />
+      <Dummy />
+      <Dummy />
+      <Dummy />
+      <Dummy />
     </Wrapper>
   );
 };

--- a/src/organisms/navbar/navbar.tsx
+++ b/src/organisms/navbar/navbar.tsx
@@ -1,4 +1,6 @@
-import React, { FC, useRef, useState } from 'react';
+import React, {
+  FC, useRef, useState,
+} from 'react';
 import { ButtonAtom } from '../../atoms/buttons/button';
 import { ConnectWalletButton } from '../../atoms/connectWalletButton/connectWalletButton';
 import { ArrowLeftIcon } from '../../atoms/icons';
@@ -8,6 +10,7 @@ import { IdenticonComponent } from '../../atoms/identicon/Identicon';
 import { Text } from '../../atoms/texts/text';
 import useBreakpoint, { Breakpoints } from '../../hooks/useBreakpoint';
 import { useClickOutside } from '../../utils/useClickOutside';
+import { useScrollDirection } from '../../utils/useOnSwipe';
 import { UserMenu } from './components/UserMenu/UserMenu';
 import {
   IdenticonContainer,
@@ -31,12 +34,15 @@ export const Navbar: FC<NavbarProps> = ({
   const breakpoint = useBreakpoint();
   const clickRef = useRef(null);
   useClickOutside(clickRef, () => setIsMenuOpen(false));
+
+  const direction = useScrollDirection(130);
   return (
     <>
       <NavbarContainer
         bottomSpacing={bottomSpacing}
         isMenuOpen={isMenuOpen}
         account={account}
+        direction={direction}
       >
         <NavbarMainContent>
           <NavbarLeftSide>

--- a/src/organisms/navbar/styles.tsx
+++ b/src/organisms/navbar/styles.tsx
@@ -1,45 +1,47 @@
 import { css } from 'styled-components';
 import { tablet } from '../../layouts/breakpoints';
 import { Styled } from '../../theme';
+import { NavbarContainerProps } from './types';
 
 const FlexBase = Styled.div`
   display: flex;
   align-items: center;
 `;
 
-export const NavbarContainer = Styled(FlexBase)<{ isMenuOpen?: boolean, account?: string | null, bottomSpacing: boolean }>`
-  position: sticky;
-  top: 0;
-  right: 0;
+export const NavbarContainer = Styled(FlexBase)<NavbarContainerProps>`
+  position: fixed;
   display: flex;
+  top: 0;
+  left: 0;
   flex-direction: column;
   justify-content: center;
+  gap: 8px;
+  width: 100%;
+  
+  z-index: ${({ theme }) => theme.zIndex.NAVBAR};
   background-color: ${({ theme }) => theme.containerAndCardShades.SHADE_PLUS_3};
   box-shadow: ${({ theme, bottomSpacing }) => bottomSpacing && theme.dropShadow.REGULAR};
-  padding: 16px 24px;
-  z-index: ${({ theme }) => theme.zIndex.NAVBAR};
-  gap: 24px;
   margin-bottom: ${({ bottomSpacing }) => bottomSpacing && '24px'};
 
-  ${tablet(css<{ isMenuOpen?: boolean, account?: string | null }>`
+  ${tablet(css<Pick<NavbarContainerProps, 'account' | 'isMenuOpen' | 'direction'>>`
+    top: ${({ direction }) => (direction === 'up' ? 0 : '-400px')};
+    transform: ${({ direction }) => (direction === 'up' ? 'scale(1)' : 'scale(0.8)')};
     gap: 0;
     justify-content: flex-start;
-    max-height: ${({ isMenuOpen, account }) => (!isMenuOpen ? '104px' : account ? '239px' : '164px')};
-    transition: max-height 200ms ease-in-out;
     border-radius: ${({ isMenuOpen }) => (isMenuOpen ? '0px 0px 12px 12px' : 'none')};
+    transition: top 0.3s ease-in-out, transform 0.3s cubic-bezier(1,.12,1,.04);
   `)}
 `;
 
 export const NavbarMainContent = Styled.div`
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
-  width: 100%;
   height: 42px;
-
+  width: calc(100vw - 32px);
+  padding: 8px;
+  
   ${tablet(css<{ isMenuOpen?: boolean }>`
-    height: 104px;
-    min-height: 104px;
+    height: 56px;
   `)}
 `;
 

--- a/src/organisms/navbar/types.ts
+++ b/src/organisms/navbar/types.ts
@@ -10,3 +10,7 @@ export interface NavbarProps {
   account?: ConnectButtonProps['account']
   bottomSpacing?: boolean
 }
+
+type IsMenuOpen = { isMenuOpen?: boolean };
+type Direction = { direction: 'up' | 'down' };
+export type NavbarContainerProps = Pick<NavbarProps, 'account' | 'bottomSpacing'> & IsMenuOpen & Direction;

--- a/src/utils/useOnSwipe.ts
+++ b/src/utils/useOnSwipe.ts
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export const useScrollDirection = (threshold: number = 100) => {
+  const [scrollDirection, setScrollDirection] = useState<'up' | 'down'>('up');
+
+  const blocking = useRef(false);
+  const prevScrollY = useRef(0);
+
+  useEffect(() => {
+    prevScrollY.current = window.pageYOffset;
+
+    const updateScrollDirection = () => {
+      const scrollY = window.pageYOffset;
+
+      if (Math.abs(scrollY - prevScrollY.current) >= threshold) {
+        const newScrollDirection = scrollY > prevScrollY.current ? 'down' : 'up';
+
+        setScrollDirection(newScrollDirection);
+
+        prevScrollY.current = scrollY > 0 ? scrollY : 0;
+      }
+
+      blocking.current = false;
+    };
+
+    const onScroll = () => {
+      if (!blocking.current) {
+        blocking.current = true;
+        window.requestAnimationFrame(updateScrollDirection);
+      }
+    };
+
+    window.addEventListener('scroll', onScroll);
+
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [scrollDirection]);
+
+  return scrollDirection;
+};


### PR DESCRIPTION
1. added few keyframes and animations.
2. Added fadein to overlay
3. Added slide/fade in to modal and added reverse functionality on close. I honestly think there must be simpler way than what i did especially with the timeout but i just couldn't figure it out. 
   It seems that animation like those could take advantage of tweenjs but i would like some feedback from everyone about the general feel of the animation. If its good i might quickly switch it to use tweenjs to make it more performant and smooth.
4. Changed position of navbar, its now fixed as before with sticky position it would push down the entire page whenever you expanded it on mobile. After that change i had to add 58px padding to layouts (since navbar and page do not collide anymore)
5. Added useScrollDirection that takes offset as param, you can use it to detect which direction user started scrolling to. 
6. Changed the look of navbar on request of michal. 
7. Added animation to navbar appearing/disappearing. 