### PR TITLE
adding option to make identicon not a link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cielo-finance/component-library",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Lightweight react component library build with atomic design.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/identicon/Identicon.stories.tsx
+++ b/src/atoms/identicon/Identicon.stories.tsx
@@ -80,6 +80,7 @@ NoInteraction.args = {
   id: 'someRandomString',
   hasInteraction: false,
   size: 'big',
+  isLink: false,
 };
 
 WithTealMarkBig.args = {

--- a/src/atoms/identicon/Identicon.styles.ts
+++ b/src/atoms/identicon/Identicon.styles.ts
@@ -4,7 +4,7 @@ import { tablet } from '../../layouts/breakpoints';
 import { Styled } from '../../theme';
 import { IdenticonProps, MarkedIdenticonProps } from './types';
 
-export const Container = Styled.a<Pick<IdenticonProps, 'hasInteraction' | 'size'>>`
+export const Container = Styled.div<Pick<IdenticonProps, 'hasInteraction' | 'size'>>`
   height: ${({ size }) => (size === 'big' ? '36px' : '24px')};
   width: ${({ size }) => (size === 'big' ? '36px' : '24px')};
   background-color: ${({ theme }) => theme.containerAndCardShades.SHADE_PLUS_2};

--- a/src/atoms/identicon/Identicon.tsx
+++ b/src/atoms/identicon/Identicon.tsx
@@ -4,9 +4,10 @@ import { Container } from './Identicon.styles';
 import { IdenticonProps } from './types';
 
 export const IdenticonComponent = ({
-  size, id, hasInteraction, onClick, href, target, onMouseEnter,
+  size, id, hasInteraction, onClick, href, target, onMouseEnter, isLink = true,
 }: IdenticonProps) => (
   <Container
+    as={isLink ? 'a' : undefined}
     size={size}
     hasInteraction={hasInteraction}
     onClick={onClick}

--- a/src/atoms/identicon/types.ts
+++ b/src/atoms/identicon/types.ts
@@ -10,6 +10,7 @@ export type IdenticonProps = {
   href?: string;
   target?: string;
   onMouseEnter?: () => void;
+  isLink?: boolean;
 };
 
 export type MarkedIdenticonProps = {


### PR DESCRIPTION

# Description

To avoid dom nesting issues and errors there are times when the identicon should not be an `a` tag, so I have added an optional `isLink` property with a default value of true. However if we pass false here then the identicon container will be a `div`.

---


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* Hardware: Android/iphone/macbook/pc/laptop

## Was this feature tested on all the browsers?

- [x] Chrome/Brave
- [] Firefox
- [] Safari 

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Storybook covers all new/pre-existing variations without need to change controls to test it
- [x] I have upgraded version in package.json
- [x] I have assigned QA and Reviewers
- [x] I have labeled the PR accordingly
- [ ] I have updated time spent in my jira ticket
- [ ] Build succeeded


---


## Notes for QA

## Notes for Devs

I have passed a default value of true here so that it is not a breaking change for any existing components that use identicon.
