### PR TITLE
Fe 1040 add outline to disabled state for buttons shade 4 1 5 px

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cielo-finance/component-library",
-  "version": "2.0.4-beta",
+  "version": "2.0.5-beta",
   "description": "Lightweight react component library build with atomic design.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/buttons/button.stories.tsx
+++ b/src/atoms/buttons/button.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { ButtonAtom } from './button';
+import { ButtonAtom, ButtonWrapper } from './button';
 import { IconWrapper } from '../icons/iconWrapper';
 import { DashboardStandard } from '../icons';
 
@@ -43,7 +43,11 @@ const WithIconR = (isText = true) => (
 );
 const Template: ComponentStory<typeof ButtonAtom> = (args) => {
   const { children } = args;
-  return <ButtonAtom {...args}>{children}</ButtonAtom>;
+  return (
+    <ButtonWrapper>
+      <ButtonAtom {...args}>{children}</ButtonAtom>
+    </ButtonWrapper>
+  );
 };
 
 const TemplateHover: ComponentStory<typeof ButtonAtom> = (args) => {

--- a/src/atoms/buttons/button.tsx
+++ b/src/atoms/buttons/button.tsx
@@ -37,7 +37,7 @@ const ButtonPrimary = Styled(Button) <Pick<ButtonProps, 'width'>>`
   ${(props) => props.disabled && css`
       background: ${props.theme.containerAndCardShades.SHADE_PLUS_3};
       color: ${props.theme.containerAndCardShades.SHADE_PLUS_1};
-      border: 2px solid transparent;
+      border: ${({ theme }) => `1.5px solid ${theme.containerAndCardShades.BG_SHADE_PLUS_4}`};
 
       svg {
         fill: ${props.theme.containerAndCardShades.SHADE_PLUS_1}!important;
@@ -70,7 +70,7 @@ const ButtonSecondary = Styled(Button) <Pick<ButtonProps, 'width' | 'height'>>`
     transition: background 0.45s ease;
       background: ${props.theme.containerAndCardShades.SHADE_PLUS_3};
       color: ${props.theme.containerAndCardShades.SHADE_PLUS_1};
-      border: 2px solid transparent;
+      border: ${({ theme }) => `1.5px solid ${theme.containerAndCardShades.BG_SHADE_PLUS_4}`};
 
       svg {
         fill: ${props.theme.containerAndCardShades.SHADE_PLUS_1}!important;
@@ -110,7 +110,7 @@ const ButtonTertiary = Styled(Button) <Pick<ButtonProps, 'width' | 'height'>>`
   ${(props) => props.disabled && css`
       background: ${props.theme.containerAndCardShades.SHADE_PLUS_3};
       color: ${props.theme.containerAndCardShades.SHADE_PLUS_1};
-      border: 2px solid transparent;
+      border: ${({ theme }) => `1.5px solid ${theme.containerAndCardShades.BG_SHADE_PLUS_4}`};
 
       svg {
         fill: ${props.theme.containerAndCardShades.SHADE_PLUS_1}!important;

--- a/src/atoms/buttons/button.tsx
+++ b/src/atoms/buttons/button.tsx
@@ -3,6 +3,11 @@ import { css } from 'styled-components';
 import { Styled } from '../../theme';
 import { ButtonProps, GenericStylingProps } from './types';
 
+export const ButtonWrapper = Styled.div`
+  padding: 50px;
+  background: ${({ theme }) => theme.containerAndCardShades.SHADE_PLUS_3};
+`;
+
 const Button = Styled.button<GenericStylingProps>`
   transition: 0.3s;
   font-size: 14px;

--- a/src/atoms/icons/index.ts
+++ b/src/atoms/icons/index.ts
@@ -107,6 +107,7 @@ export * from './generalIcons/filledStyle/LeaderboardStandard';
 export * from './generalIcons/filledStyle/Suggested';
 export * from './generalIcons/filledStyle/ChainScan';
 export * from './generalIcons/filledStyle/Follow';
+export * from './generalIcons/filledStyle/TrendingFlame';
 
 // navigationIcons
 export * from './navigationIcons/ArrowDownIcon';
@@ -240,5 +241,4 @@ export * from './feed/Swap';
 export * from './feed/Withdraw';
 export * from './feed/FilterTokens';
 export * from './feed/FilterTx';
-export * from './feed/Flame';
 export * from './feed/Timestamp';

--- a/src/atoms/texts/text.tsx
+++ b/src/atoms/texts/text.tsx
@@ -21,7 +21,7 @@ export const Text: FC<TextProps> = ({
       </StyledA>
     );
   }
-  if ((['L', 'M', 'S', 'Button', 'Caption', 'Tiny', 'Overline'].includes(textType))) {
+  if ((['L', 'M', 'S', 'Caption', 'Tiny', 'Overline'].includes(textType))) {
     return (
       <StyledP
         textDecoration={textDecoration}

--- a/src/atoms/texts/textGenerator.ts
+++ b/src/atoms/texts/textGenerator.ts
@@ -3,7 +3,6 @@ export const P_FONTSIZE = Object.freeze({
   Tiny: 10,
   Caption: 12,
   S: 14,
-  Button: 14,
   M: 14,
   L: 16,
 });
@@ -12,7 +11,6 @@ export const P_LINE_HEIGHT = Object.freeze({
   Tiny: 12,
   Caption: 16,
   S: 18,
-  Button: 20,
   M: 20,
   L: 20,
 });

--- a/src/atoms/texts/types.ts
+++ b/src/atoms/texts/types.ts
@@ -3,8 +3,6 @@ export type BodySizes =
   | 'L-Bold'
   | 'M-Regular'
   | 'M-Bold'
-  | 'Button-Bold'
-  | 'Button-Regular'
   | 'S-Regular'
   | 'S-Bold'
   | 'Caption-Regular'


### PR DESCRIPTION

# Description

add new 1.5x border to buttons (primary, secondary and tertiary) in disabled state

---

Fixes # (issue)
[FE-1040](https://uniwhales.atlassian.net/browse/FE-1040?atlOrigin=eyJpIjoiMmU2YWQxZDgxYjkzNGIyMzlkNjc5NjJjMGIxZDQzNjgiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* Hardware: Android/iphone/macbook/pc/laptop

## Was this feature tested on all the browsers?

- [x] Chrome/Brave
- [ ] Firefox
- [ ] Safari 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Storybook covers all new/pre-existing variations without need to change controls to test it
- [x] I have upgraded version in package.json
- [x] I have assigned QA and Reviewers
- [x] I have labeled the PR accordingly
- [ ] I have updated time spent in my jira ticket
- [ ] Build succeeded


---


## Notes for QA

## Notes for Devs


[FE-1040]: https://uniwhales.atlassian.net/browse/FE-1040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ