### PR TITLE
move styles out of react select style object and into styled componen…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cielo-finance/component-library",
-  "version": "2.0.19-beta",
+  "version": "2.0.20-beta",
   "description": "Lightweight react component library build with atomic design.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/inputs/select.tsx
+++ b/src/atoms/inputs/select.tsx
@@ -113,11 +113,14 @@ export const Placeholder = Styled.div`
   gap: 6px;
 `;
 
-const OptionWrapper = Styled.div`
-  background-color: ${({ theme }) => theme.containerAndCardShades.SHADE_PLUS_2};
+const OptionWrapper = Styled.div<{ isSelected: boolean }>`
+  background-color: ${({ theme, isSelected }) => (isSelected ? theme.colors.primary.MAIN_BLUE : theme.containerAndCardShades.SHADE_PLUS_2)};
   &:nth-of-type(2n) {
-    background-color: ${({ theme }) => theme.containerAndCardShades.SHADE_PLUS_1};
+    background-color: ${({ theme, isSelected }) => (isSelected ? theme.colors.primary.MAIN_BLUE : theme.containerAndCardShades.SHADE_PLUS_1)};
   };
+  :hover {
+    background-color: ${({ theme, isSelected }) => !isSelected && theme.textShades.SHADE_MINUS_1};
+  }
 `;
 
 const OptionLabelContainer = Styled.label<{ addPadding: boolean }>`
@@ -190,24 +193,6 @@ const colourStyles: StylesConfig<StyledProps, false> = {
     ...defaultStyles,
     border: 'none',
     cursor: 'pointer',
-  }),
-  option: (defaultStyles, {
-    isFocused, isSelected, theme, readOnly, label,
-  }: StyledProps) => ({
-    ...defaultStyles,
-    overflowWrap: label && label.includes(' ') ? 'break-word' : 'anywhere',
-    display: 'flex',
-    transition: 'background 0.1s ease',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    cursor: 'pointer',
-    color: theme.textShades.SHADE_MINUS_3,
-    background: isSelected ? theme.colors.primary.MAIN_BLUE
-      : isFocused ? readOnly ? 'none' : 'theme.containerAndCardShades.NEUTRAL_SHADE_0' : undefined,
-    '&:hover': {
-      background: !isSelected ? theme.textShades.SHADE_MINUS_1 : undefined,
-      color: theme.colors.system.WHITE,
-    },
   }),
   menu: (defaultStyles) => ({
     ...defaultStyles,
@@ -298,7 +283,7 @@ const OptionComponent = (props: any) => {
   // icons and current option does not
   const addPadding = (optionsHaveIcon.length > 0 || groupHasIcons) && !hasIcon;
   return (
-    <OptionWrapper>
+    <OptionWrapper isSelected={isSelected}>
       <components.Option {...props} label={data.label}>
         {!readOnly && isCheckBox ? (
           <>


### PR DESCRIPTION
# Description

Fixes strange effect when unselected elements inside select. Moved styles out of react select style object and into custom component

---

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* Hardware: Android/iphone/macbook/pc/laptop

## Was this feature tested on all the browsers?

- [x] Chrome/Brave
- [] Firefox
- [] Safari 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Storybook covers all new/pre-existing variations without need to change controls to test it
- [x] I have upgraded version in package.json
- [x] I have assigned QA and Reviewers
- [x] I have labeled the PR accordingly
- [ ] I have updated time spent in my jira ticket
- [ ] Build succeeded


---


## Notes for QA

## Notes for Devs
