### PR TITLE
Wallet label update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cielo-finance/component-library",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Lightweight react component library build with atomic design.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/walletLabel/types.ts
+++ b/src/atoms/walletLabel/types.ts
@@ -1,6 +1,6 @@
-import { TextPropsBase } from '../shortText/types';
+import { ShortTextProps, TextPropsBase } from '../shortText/types';
 
-export type WalletLabelProps = TextPropsBase & {
+export type WalletLabelProps = TextPropsBase & ShortTextProps & {
   label?: string;
   address: string;
   width?: string;

--- a/src/atoms/walletLabel/walletLabel.tsx
+++ b/src/atoms/walletLabel/walletLabel.tsx
@@ -7,7 +7,7 @@ import { WalletLabelProps } from './types';
 
 export const WalletLabel = (
   {
-    label, address, size, color, chars = 5, width,
+    label, address, size, color, chars = 5, width, target, href,
   }: WalletLabelProps,
 ) => {
   const labelHasSpaces = !!label?.trim().includes(' ');
@@ -21,6 +21,8 @@ export const WalletLabel = (
           size={size ?? '14-Regular'}
           color={color}
           chars={limit}
+          target={target}
+          href={href}
         />
       </Container>
     );
@@ -28,13 +30,13 @@ export const WalletLabel = (
   if (label) {
     return (
       <Container width={width} breakWord={labelHasSpaces}>
-        <Text size={size ?? '14-Regular'} color={color}>{label}</Text>
+        <Text target={target} href={href} size={size ?? '14-Regular'} color={color}>{label}</Text>
       </Container>
     );
   }
   return (
     <Container width={width} breakWord={labelHasSpaces}>
-      <Text size={size ?? '14-Regular'} color={color}>{shortenAddressTo11Chars(address)}</Text>
+      <Text target={target} href={href} size={size ?? '14-Regular'} color={color}>{shortenAddressTo11Chars(address)}</Text>
     </Container>
   );
 };


### PR DESCRIPTION

# Description

Extend wallet label component to allow `target` and `href` for when we have links

Needed for unifying the identicon and label component together
