### PR TITLE
Fe 1196 a component comming soon looks strange on the configure btn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cielo-finance/component-library",
-  "version": "2.2.2-modals",
+  "version": "2.2.3",
   "description": "Lightweight react component library build with atomic design.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/molecules/tooltip/TooltipComponent.tsx
+++ b/src/molecules/tooltip/TooltipComponent.tsx
@@ -4,7 +4,7 @@ import { localTheme } from '../../theme';
 import { TooltipProps } from './types';
 
 export const SimpleTooltip = ({
-  label, children, position = 'top', arrowSize = 5, opened,
+  label, children, position = 'top', opened,
   zIndex,
 }: TooltipProps) => {
   const theme = localTheme();
@@ -17,14 +17,17 @@ export const SimpleTooltip = ({
       withArrow
       offset={4}
       closeDelay={0}
-      arrowSize={arrowSize}
+      arrowSize={5}
       opened={opened}
       zIndex={zIndex}
       styles={{
         arrow: {
           backgroundColor: theme.containerAndCardShades.BG_SHADE_PLUS_4,
           border: `2px solid ${theme.containerAndCardShades.SHADE_PLUS_1}`,
-          padding: 2,
+          bottom: position === 'top' ? '-5px !important' : undefined,
+          top: position === 'bottom' ? '-5px !important' : undefined,
+          left: position === 'right' ? '-5px !important' : undefined,
+          right: position === 'left' ? '-5px !important' : undefined,
         },
         tooltip: {
           backgroundColor: theme.containerAndCardShades.BG_SHADE_PLUS_4,

--- a/src/molecules/tooltip/tooltipComponent.stories.tsx
+++ b/src/molecules/tooltip/tooltipComponent.stories.tsx
@@ -1,14 +1,15 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React, { useState } from 'react';
+import React from 'react';
 import { Styled, Theme } from '../../theme';
 import { SimpleTooltip } from './TooltipComponent';
 import { Text } from '../../atoms/texts/text';
-import { ButtonAtom } from '../../atoms/buttons/button';
 
 const Wrapper = Styled.div`
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  justify-content: center;
+  align-items: center;
+  gap: 128px;
 `;
 export default {
   title: 'Molecules/SimpleTooltip',
@@ -16,37 +17,50 @@ export default {
   argTypes: {},
 } as ComponentMeta<typeof SimpleTooltip>;
 
-const Template: ComponentStory<typeof SimpleTooltip> = () => {
-  const [text, setText] = useState('Not Clicked');
-  return (
-    <Wrapper>
-      <SimpleTooltip
-        position="bottom"
-        opened
-        zIndex={Theme.zIndex.OVERLAY}
-        label={(
-          <div>
-            <Wrapper>
-              <Text>{text}</Text>
-              <ButtonAtom
-                onClick={() => {
-                  setText('Clicked');
-                }}
-                buttonVariant="primary"
-              />
-            </Wrapper>
-          </div>
-        )}
-      >
-        <ButtonAtom
-          buttonVariant="primary"
-        >
-          Open
-        </ButtonAtom>
-      </SimpleTooltip>
-    </Wrapper>
+const Template: ComponentStory<typeof SimpleTooltip> = () => (
+  <Wrapper>
+    <SimpleTooltip
+      position="bottom"
+      zIndex={Theme.zIndex.OVERLAY}
+      label="content bottom"
+      allowPointerEvents
+    >
+      <div>
+        <Text>target bottom</Text>
+      </div>
+    </SimpleTooltip>
+    <SimpleTooltip
+      position="top"
+      zIndex={Theme.zIndex.OVERLAY}
+      label="content top"
+      allowPointerEvents
+    >
+      <div>
+        <Text>target top</Text>
+      </div>
+    </SimpleTooltip>
+    <SimpleTooltip
+      position="left"
+      zIndex={Theme.zIndex.OVERLAY}
+      label="content left"
+      allowPointerEvents
+    >
+      <div>
+        <Text>target left</Text>
+      </div>
+    </SimpleTooltip>
+    <SimpleTooltip
+      position="right"
+      zIndex={Theme.zIndex.OVERLAY}
+      label="content right"
+      allowPointerEvents
+    >
+      <div>
+        <Text>target right</Text>
+      </div>
+    </SimpleTooltip>
+  </Wrapper>
 
-  );
-};
+);
 
 export const SimpleTooltipComponent = Template.bind({});

--- a/src/molecules/tooltip/types.ts
+++ b/src/molecules/tooltip/types.ts
@@ -5,7 +5,6 @@ export interface TooltipProps {
   children: ReactNode;
   label: ReactNode;
   position?: 'bottom' | 'left' | 'right' | 'top';
-  arrowSize?: number;
   opened?: boolean;
   allowPointerEvents?: boolean;
   zIndex?: ZIndex;


### PR DESCRIPTION

# Description

Fixes issues with strange placement of arrow in tooltip component.

I have removed the optional `arrowSize` prop, as to get the placement correct we must know the arrow size. I think this is better anyway as we should be using consistent arrow sizing throughout the application.

Added correct styling overrides to show the arrow in the correct placement.

*Note:* I had to use the `!important` property here as mantine would always override the styles otherwise.

**Removing the arrow sizing will be a breaking change inside Cielo. We are currently using it in one place, so this will have to be removed otherwise the build will fail**

---

Fixes # (issue)
[FE-1196](https://uniwhales.atlassian.net/browse/FE-1196?atlOrigin=eyJpIjoiZjVjY2E4NjJkMjk5NDY1YmFmODA0M2M0Njc0MWIwYmYiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* Hardware: Android/iphone/macbook/pc/laptop

## Was this feature tested on all the browsers?

- [x] Chrome/Brave
- [] Firefox
- [] Safari 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Storybook covers all new/pre-existing variations without need to change controls to test it
- [x] I have upgraded version in package.json
- [x] I have assigned QA and Reviewers
- [x] I have labeled the PR accordingly
- [ ] I have updated time spent in my jira ticket
- [ ] Build succeeded


---


## Notes for QA

## Notes for Devs


[FE-1196]: https://uniwhales.atlassian.net/browse/FE-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ