### PR TITLE
Fe 1324

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cielo-finance/component-library",
-  "version": "2.2.14",
+  "version": "2.2.14-dev-FE-1324-1",
   "description": "Lightweight react component library build with atomic design.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cielo-finance/component-library",
-  "version": "2.2.14-dev-FE-1324-1",
+  "version": "2.2.15",
   "description": "Lightweight react component library build with atomic design.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/inputs/select.stories.tsx
+++ b/src/atoms/inputs/select.stories.tsx
@@ -5,7 +5,7 @@ import {
 } from './select';
 import { IconWrapper } from '../icons/iconWrapper';
 import {
-  BinanceColor, BobaColor, EthereumColor, FantomColor, SettingsBars,
+  BinanceColor, BobaColor, EthereumColor, FantomColor, SettingsBars, ZkEvmColor,
 } from '../icons';
 import { Text } from '../texts/text';
 import { Wrapper } from './input';
@@ -78,10 +78,13 @@ const ChainOptions = [
     id: 4, value: 'noicon', label: 'No Icon', order: 4,
   },
   {
-    id: 5, value: 'bobo', label: 'Bobo', icon: <IconWrapper height="16px" width="16px" icon={<BobaColor />} />, order: 4,
+    id: 5, value: 'bobo', label: 'Bobo', icon: <IconWrapper height="16px" width="16px" icon={<BobaColor />} />, order: 5,
   },
   {
-    id: 6, value: 'noicon', label: 'No Icon', order: 4,
+    id: 6, value: 'noicon', label: 'No Icon', order: 6,
+  },
+  {
+    id: 5, value: 'polygonzkevm', label: 'Polygon ZKevm', icon: <IconWrapper height="16px" width="16px" icon={<ZkEvmColor />} />, order: 7,
   },
 ];
 
@@ -144,14 +147,14 @@ Primary.parameters = {
   backgrounds: { default: 'dark theme' },
 };
 Primary.args = {
-  width: '226px',
+  width: '150px',
   selectOptions: ChainOptions,
   isMulti: false,
   readOnly: false,
   placeholder: 'DEX filters',
   isXL: false,
   showValue: true,
-  showOnTop: true,
+  smallText: true,
 };
 
 PrimaryIcon.args = {

--- a/src/atoms/inputs/select.tsx
+++ b/src/atoms/inputs/select.tsx
@@ -57,6 +57,7 @@ export interface SelectProps<T extends SelectVariation> {
   errorMessage?: string
   showOnTop?: boolean
   noOptionsMessage?:string;
+  smallText?: boolean;
 }
 
 interface StyledProps {
@@ -126,13 +127,14 @@ const OptionWrapper = Styled.div<{ isSelected: boolean, hasGroups: boolean, show
 
 `;
 
-const OptionLabelContainer = Styled.label<{ addPadding: boolean }>`
+const OptionLabelContainer = Styled.label<{ addPadding: boolean, smallText?:boolean }>`
   padding-left: ${({ addPadding }) => addPadding && '24px'};
   display: flex;
   align-items: center;
   gap: 8px;
   cursor: pointer;
   word-break: break-all;
+  font-size: ${({ smallText }) => smallText && '12px'};
 `;
 
 const ClearButtonContainer = Styled.div`
@@ -298,7 +300,7 @@ const colourStyles: StylesConfig<StyledProps, false> = {
 
 const OptionComponent = (props: any) => {
   const {
-    label, isSelected, readOnly, isCheckBox, data, options, selectProps,
+    label, isSelected, readOnly, isCheckBox, data, options, selectProps, smallText,
   } = props;
   // check if any options have icons
   const optionsHaveIcon = options.filter((o: { icon: JSX.Element }) => o.icon);
@@ -307,7 +309,6 @@ const OptionComponent = (props: any) => {
   const groupOptions = groups
     && groups.map((g: { options: Option[]; }) => g.options.filter((o: Option) => o.icon));
   const groupHasIcons = groupOptions.some((group: string | any[]) => group.length > 0);
-
   // check if individual option has an icon
   const hasIcon = !!data.icon;
   // show padding if any options have
@@ -331,7 +332,7 @@ const OptionComponent = (props: any) => {
         {!readOnly && isCheckBox ? (
 
           <CheckboxOptionContainer>
-            <OptionLabelContainer addPadding={addPadding}>
+            <OptionLabelContainer addPadding={addPadding} smallText={smallText}>
               {data.icon && <IconWrapper height="14px" width="14px" icon={data.icon} />}
               {label}
             </OptionLabelContainer>
@@ -344,7 +345,7 @@ const OptionComponent = (props: any) => {
             />
           </CheckboxOptionContainer>
         ) : (
-          <OptionLabelContainer addPadding={addPadding}>
+          <OptionLabelContainer smallText={smallText} addPadding={addPadding}>
             {data.icon && <IconWrapper height="14px" width="14px" icon={data.icon} />}
             {label}
           </OptionLabelContainer>
@@ -462,6 +463,7 @@ export const Select = <T extends SelectVariation>({
   ref,
   showOnTop,
   noOptionsMessage,
+  smallText = false,
 }: SelectProps<T>) => {
   const theme = localTheme();
   const customNoOptionsMessage = () => noOptionsMessage || 'No options';
@@ -486,7 +488,7 @@ export const Select = <T extends SelectVariation>({
         onInputChange={(e) => onInputChange && onInputChange(e)}
         components={{
           Option: (props) => OptionComponent({
-            ...props, readOnly, isCheckBox,
+            ...props, readOnly, isCheckBox, smallText,
           }),
           IndicatorSeparator: () => null,
           ClearIndicator: (props) => ClearIndicator(


### PR DESCRIPTION

# Description

Add optional small text prop for dropdowns where width is narrow and we want the option to reduce text size to stop text wrapping across two lines

---


Fixes # (issue)
[FE-1324](https://uniwhales.atlassian.net/browse/FE-1324?atlOrigin=eyJpIjoiMTEwN2YzMDRiODQ1NDgyODk5YzU1OWRmMzhjOWZlNjAiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* Hardware: Android/iphone/macbook/pc/laptop

## Was this feature tested on all the browsers?

- [x] Chrome/Brave
- [] Firefox
- [] Safari 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Storybook covers all new/pre-existing variations without need to change controls to test it
- [x] I have upgraded version in package.json
- [ ] I have assigned QA and Reviewers
- [x] I have labeled the PR accordingly
- [x] I have updated time spent in my jira ticket
- [x] Build succeeded


---


## Notes for QA

## Notes for Devs


[FE-1324]: https://uniwhales.atlassian.net/browse/FE-1324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ